### PR TITLE
Add slider for window start and auto update visualization

### DIFF
--- a/data_generator_ver1/index.html
+++ b/data_generator_ver1/index.html
@@ -88,10 +88,12 @@
                             <input type="number" id="windowSize" value="50" min="10" max="200">
                         </div>
                         
-                        <div class="control-group window-nav">
-                            <button id="windowLeft" class="btn-secondary">◀</button>
+                        <div class="control-group">
+                            <label for="windowStart">윈도우 시작 위치:</label>
+                            <input type="range" id="windowStart" value="0" min="0" max="100" step="1">
+                        </div>
+                        <div class="control-group">
                             <span id="windowRange">범위: -</span>
-                            <button id="windowRight" class="btn-secondary">▶</button>
                         </div>
                     </div>
                 </div>

--- a/data_generator_ver1/main.js
+++ b/data_generator_ver1/main.js
@@ -35,8 +35,7 @@ class HighDimensionalDataApp {
         // 윈도우 컨트롤
         this.windowEnabledCheckbox = document.getElementById('windowEnabled');
         this.windowSizeInput = document.getElementById('windowSize');
-        this.windowLeftBtn = document.getElementById('windowLeft');
-        this.windowRightBtn = document.getElementById('windowRight');
+        this.windowStartSlider = document.getElementById('windowStart');
         this.windowRangeSpan = document.getElementById('windowRange');
         
         // 이벤트 리스너 등록
@@ -65,24 +64,19 @@ class HighDimensionalDataApp {
         this.windowEnabledCheckbox.addEventListener('change', (e) => {
             this.visualizer.toggleWindow(e.target.checked);
             this.updateWindowControls();
+            this.updateVisualization();
         });
-        
-        this.windowSizeInput.addEventListener('change', (e) => {
+
+        this.windowSizeInput.addEventListener('input', (e) => {
             const xDimIndex = parseInt(this.xAxisSelect.value || 0);
             this.visualizer.resizeWindow(parseFloat(e.target.value), xDimIndex);
             this.updateWindowControls();
-        });
-        
-        this.windowLeftBtn.addEventListener('click', () => {
-            const xDimIndex = parseInt(this.xAxisSelect.value || 0);
-            this.visualizer.moveWindow('left', xDimIndex);
-            this.updateWindowControls();
             this.updateVisualization();
         });
-        
-        this.windowRightBtn.addEventListener('click', () => {
+
+        this.windowStartSlider.addEventListener('input', (e) => {
             const xDimIndex = parseInt(this.xAxisSelect.value || 0);
-            this.visualizer.moveWindow('right', xDimIndex);
+            this.visualizer.setWindowStart(parseFloat(e.target.value), xDimIndex);
             this.updateWindowControls();
             this.updateVisualization();
         });
@@ -192,41 +186,32 @@ class HighDimensionalDataApp {
         const newWindowEnabled = this.windowEnabledCheckbox.cloneNode(true);
         this.windowEnabledCheckbox.parentNode.replaceChild(newWindowEnabled, this.windowEnabledCheckbox);
         this.windowEnabledCheckbox = newWindowEnabled;
-        
+
         const newWindowSize = this.windowSizeInput.cloneNode(true);
         this.windowSizeInput.parentNode.replaceChild(newWindowSize, this.windowSizeInput);
         this.windowSizeInput = newWindowSize;
-        
-        const newWindowLeft = this.windowLeftBtn.cloneNode(true);
-        this.windowLeftBtn.parentNode.replaceChild(newWindowLeft, this.windowLeftBtn);
-        this.windowLeftBtn = newWindowLeft;
-        
-        const newWindowRight = this.windowRightBtn.cloneNode(true);
-        this.windowRightBtn.parentNode.replaceChild(newWindowRight, this.windowRightBtn);
-        this.windowRightBtn = newWindowRight;
+
+        const newWindowStart = this.windowStartSlider.cloneNode(true);
+        this.windowStartSlider.parentNode.replaceChild(newWindowStart, this.windowStartSlider);
+        this.windowStartSlider = newWindowStart;
         
         // 윈도우 컨트롤 이벤트 재등록
         this.windowEnabledCheckbox.addEventListener('change', (e) => {
             this.visualizer.toggleWindow(e.target.checked);
             this.updateWindowControls();
+            this.updateVisualization();
         });
-        
-        this.windowSizeInput.addEventListener('change', (e) => {
+
+        this.windowSizeInput.addEventListener('input', (e) => {
             const xDimIndex = parseInt(this.xAxisSelect.value || 0);
             this.visualizer.resizeWindow(parseFloat(e.target.value), xDimIndex);
             this.updateWindowControls();
-        });
-        
-        this.windowLeftBtn.addEventListener('click', () => {
-            const xDimIndex = parseInt(this.xAxisSelect.value || 0);
-            this.visualizer.moveWindow('left', xDimIndex);
-            this.updateWindowControls();
             this.updateVisualization();
         });
-        
-        this.windowRightBtn.addEventListener('click', () => {
+
+        this.windowStartSlider.addEventListener('input', (e) => {
             const xDimIndex = parseInt(this.xAxisSelect.value || 0);
-            this.visualizer.moveWindow('right', xDimIndex);
+            this.visualizer.setWindowStart(parseFloat(e.target.value), xDimIndex);
             this.updateWindowControls();
             this.updateVisualization();
         });
@@ -307,12 +292,18 @@ class HighDimensionalDataApp {
         
         const enabled = this.windowEnabledCheckbox.checked;
         this.windowSizeInput.disabled = !enabled;
-        this.windowLeftBtn.disabled = !enabled;
-        this.windowRightBtn.disabled = !enabled;
+        this.windowStartSlider.disabled = !enabled;
         
         if (enabled && this.visualizer.windowConfig) {
-            const { xMin, xMax } = this.visualizer.windowConfig;
+            const { xMin, xMax, step, windowSize } = this.visualizer.windowConfig;
             this.windowRangeSpan.textContent = `범위: ${xMin.toFixed(1)} ~ ${xMax.toFixed(1)}`;
+            const xDimIndex = parseInt(this.xAxisSelect.value || 0);
+            const min = this.currentData.metadata.dimRangeMin[xDimIndex];
+            const max = this.currentData.metadata.dimRangeMax[xDimIndex];
+            this.windowStartSlider.min = min;
+            this.windowStartSlider.max = max - windowSize;
+            this.windowStartSlider.step = step;
+            this.windowStartSlider.value = xMin;
         } else {
             this.windowRangeSpan.textContent = '범위: 전체';
         }

--- a/data_generator_ver1/style.css
+++ b/data_generator_ver1/style.css
@@ -191,11 +191,6 @@ h2 {
     color: var(--text-primary);
 }
 
-.window-nav {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-}
 
 .btn-secondary {
     background-color: var(--secondary-color);
@@ -320,9 +315,6 @@ input[type="checkbox"] {
         grid-template-columns: 1fr;
     }
     
-    .window-nav {
-        justify-content: space-between;
-    }
     
     .chart-container {
         height: 400px;

--- a/data_generator_ver1/visualization/visualization.js
+++ b/data_generator_ver1/visualization/visualization.js
@@ -200,6 +200,29 @@ export class Visualizer {
     }
 
     /**
+     * 윈도우 시작 위치 설정
+     */
+    setWindowStart(start, xDimIndex = 0) {
+        this.windowConfig.xMin = start;
+        this.windowConfig.xMax = start + this.windowConfig.windowSize;
+
+        const metadata = this.projectionEngine.metadata;
+        if (metadata && xDimIndex < metadata.dimensions) {
+            const min = metadata.dimRangeMin[xDimIndex];
+            const max = metadata.dimRangeMax[xDimIndex];
+
+            if (this.windowConfig.xMin < min) {
+                this.windowConfig.xMin = min;
+                this.windowConfig.xMax = min + this.windowConfig.windowSize;
+            }
+            if (this.windowConfig.xMax > max) {
+                this.windowConfig.xMax = max;
+                this.windowConfig.xMin = max - this.windowConfig.windowSize;
+            }
+        }
+    }
+
+    /**
      * 윈도우 크기 변경
      */
     resizeWindow(newSize, xDimIndex = 0) {


### PR DESCRIPTION
## Summary
- replace arrow buttons with a slider to set window start
- auto-update visualization when window controls change
- update window controls when resizing or moving

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685650cefdd483319f13093e420952fb