### PR TITLE
Split visualization page and fix slider

### DIFF
--- a/data_generator_ver1/index.html
+++ b/data_generator_ver1/index.html
@@ -60,76 +60,9 @@
         <div class="output-panel">
             <h2>생성된 데이터</h2>
             <div id="dataOutput"></div>
+            <button id="viewChartBtn" class="btn-primary" disabled>그래프 생성</button>
         </div>
         
-        <div class="visualization-panel" id="vizPanel" style="display: none;">
-            <h2>2D 정사영 시각화</h2>
-            
-            <div class="viz-controls">
-                <div class="control-row">
-                    <div class="control-group">
-                        <label for="xAxis">X축 차원:</label>
-                        <select id="xAxis"></select>
-                    </div>
-                    
-                    <div class="control-group">
-                        <label for="yAxis">Y축 차원:</label>
-                        <select id="yAxis"></select>
-                    </div>
-                    
-                    <div class="control-group">
-                        <label for="colorScheme">색상 스킴:</label>
-                        <select id="colorScheme">
-                            <option value="viridis">Viridis</option>
-                            <option value="plasma">Plasma</option>
-                            <option value="coolwarm">Cool-Warm</option>
-                            <option value="rainbow">Rainbow</option>
-                        </select>
-                    </div>
-                </div>
-                
-                <div class="window-controls">
-                    <h3>윈도우 컨트롤</h3>
-                    <div class="control-row">
-                        <div class="control-group">
-                            <label>
-                                <input type="checkbox" id="windowEnabled" checked>
-                                윈도우 모드 활성화
-                            </label>
-                        </div>
-                        
-                        <div class="control-group">
-                            <label for="windowSize">윈도우 크기:</label>
-                            <input type="number" id="windowSize" value="50" min="10" max="200">
-                        </div>
-                        
-                        <div class="control-group">
-                            <label for="windowStart">윈도우 시작 위치:</label>
-                            <input type="range" id="windowStart" value="0" min="0" max="100" step="1">
-                        </div>
-                        <div class="control-group">
-                            <span id="windowRange">범위: -</span>
-                        </div>
-                        <div class="control-group">
-                            <button id="zoomInBtn" class="btn-secondary">확대</button>
-                            <button id="zoomOutBtn" class="btn-secondary">축소</button>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="dimension-filters" id="dimensionFilters">
-                    <h3>차원 필터</h3>
-                    <!-- 동적으로 생성됨 -->
-                </div>
-                
-                <button id="updateVizBtn" class="btn-primary">시각화 업데이트</button>
-                <span id="displayedCount" class="info-text"></span>
-            </div>
-            
-            <div class="chart-container">
-                <canvas id="vizChart"></canvas>
-            </div>
-        </div>
     </div>
     
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/data_generator_ver1/main.js
+++ b/data_generator_ver1/main.js
@@ -26,6 +26,7 @@ class HighDimensionalDataApp {
         this.allowDuplicatesCheckbox = document.getElementById('allowDuplicates');
         this.generateBtn = document.getElementById('generateBtn');
         this.dataOutput = document.getElementById('dataOutput');
+        this.viewChartBtn = document.getElementById('viewChartBtn');
         
         // 시각화 UI 요소
         this.vizPanel = document.getElementById('vizPanel');
@@ -45,6 +46,9 @@ class HighDimensionalDataApp {
         // 이벤트 리스너 등록 (존재 여부 확인)
         if (this.generateBtn) this.generateBtn.addEventListener('click', () => this.generateData());
         if (this.updateVizBtn) this.updateVizBtn.addEventListener('click', () => this.updateVisualization());
+        if (this.viewChartBtn) this.viewChartBtn.addEventListener('click', () => {
+            window.location.href = 'visualization.html';
+        });
         
         // 값 타입 변경 시 벡터 크기 입력 표시/숨김
         this.valueTypeSelect.addEventListener('change', (e) => {
@@ -182,6 +186,12 @@ class HighDimensionalDataApp {
 
         // 결과 표시
         this.displayData();
+
+        // 저장 및 그래프 버튼 활성화
+        if (this.viewChartBtn) {
+            localStorage.setItem('generatedData', JSON.stringify(this.currentData));
+            this.viewChartBtn.disabled = false;
+        }
         
         // 시각화 UI 초기화
         this.initializeVisualizationUI();
@@ -378,10 +388,19 @@ class HighDimensionalDataApp {
             const xDimIndex = parseInt(this.xAxisSelect.value || 0);
             const min = this.currentData.metadata.dimRangeMin[xDimIndex];
             const max = this.currentData.metadata.dimRangeMax[xDimIndex];
-            this.windowStartSlider.min = min;
-            this.windowStartSlider.max = max - windowSize;
-            this.windowStartSlider.step = 'any';
-            this.windowStartSlider.value = xMin;
+            const range = max - min;
+            if (range <= windowSize) {
+                this.windowStartSlider.min = min;
+                this.windowStartSlider.max = min;
+                this.windowStartSlider.value = min;
+                this.windowStartSlider.disabled = true;
+            } else {
+                this.windowStartSlider.disabled = false;
+                this.windowStartSlider.min = min;
+                this.windowStartSlider.max = max - windowSize;
+                this.windowStartSlider.step = 'any';
+                this.windowStartSlider.value = xMin;
+            }
         } else {
             this.windowRangeSpan.textContent = '범위: 전체';
         }

--- a/data_generator_ver1/style.css
+++ b/data_generator_ver1/style.css
@@ -351,4 +351,13 @@ input[type="checkbox"] {
     padding: 1rem;
     border-radius: 6px;
     border: 1px solid #fee2e2;
+}.close-btn {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: transparent;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
 }
+

--- a/data_generator_ver1/visualization.html
+++ b/data_generator_ver1/visualization.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>데이터 시각화</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <button id="closeBtn" class="close-btn">X</button>
+        <div class="visualization-panel" id="vizPanel" style="display: none;">
+            <h2>2D 정사영 시각화</h2>
+            
+            <div class="viz-controls">
+                <div class="control-row">
+                    <div class="control-group">
+                        <label for="xAxis">X축 차원:</label>
+                        <select id="xAxis"></select>
+                    </div>
+                    
+                    <div class="control-group">
+                        <label for="yAxis">Y축 차원:</label>
+                        <select id="yAxis"></select>
+                    </div>
+                    
+                    <div class="control-group">
+                        <label for="colorScheme">색상 스킴:</label>
+                        <select id="colorScheme">
+                            <option value="viridis">Viridis</option>
+                            <option value="plasma">Plasma</option>
+                            <option value="coolwarm">Cool-Warm</option>
+                            <option value="rainbow">Rainbow</option>
+                        </select>
+                    </div>
+                </div>
+                
+                <div class="window-controls">
+                    <h3>윈도우 컨트롤</h3>
+                    <div class="control-row">
+                        <div class="control-group">
+                            <label>
+                                <input type="checkbox" id="windowEnabled" checked>
+                                윈도우 모드 활성화
+                            </label>
+                        </div>
+                        
+                        <div class="control-group">
+                            <label for="windowSize">윈도우 크기:</label>
+                            <input type="number" id="windowSize" value="50" min="10" max="200">
+                        </div>
+                        
+                        <div class="control-group">
+                            <label for="windowStart">윈도우 시작 위치:</label>
+                            <input type="range" id="windowStart" value="0" min="0" max="100" step="1">
+                        </div>
+                        <div class="control-group">
+                            <span id="windowRange">범위: -</span>
+                        </div>
+                        <div class="control-group">
+                            <button id="zoomInBtn" class="btn-secondary">확대</button>
+                            <button id="zoomOutBtn" class="btn-secondary">축소</button>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="dimension-filters" id="dimensionFilters">
+                    <h3>차원 필터</h3>
+                    <!-- 동적으로 생성됨 -->
+                </div>
+                
+                <button id="updateVizBtn" class="btn-primary">시각화 업데이트</button>
+                <span id="displayedCount" class="info-text"></span>
+            </div>
+            
+            <div class="chart-container">
+                <canvas id="vizChart"></canvas>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script type="module" src="visualizationPage.js"></script>
+</body>
+</html>

--- a/data_generator_ver1/visualizationPage.js
+++ b/data_generator_ver1/visualizationPage.js
@@ -1,0 +1,258 @@
+import { Visualizer } from './visualization/visualization.js';
+
+class VisualizationPage {
+    constructor() {
+        const dataStr = localStorage.getItem('generatedData');
+        if (!dataStr) {
+            alert('생성된 데이터가 없습니다.');
+            window.location.href = 'index.html';
+            return;
+        }
+        this.currentData = JSON.parse(dataStr);
+        this.visualizer = new Visualizer('vizChart');
+
+        this.vizPanel = document.getElementById('vizPanel');
+        this.xAxisSelect = document.getElementById('xAxis');
+        this.yAxisSelect = document.getElementById('yAxis');
+        this.colorSchemeSelect = document.getElementById('colorScheme');
+        this.updateVizBtn = document.getElementById('updateVizBtn');
+        this.pointCountSpan = document.getElementById('displayedCount');
+        this.windowEnabledCheckbox = document.getElementById('windowEnabled');
+        this.windowSizeInput = document.getElementById('windowSize');
+        this.windowStartSlider = document.getElementById('windowStart');
+        this.windowRangeSpan = document.getElementById('windowRange');
+        this.zoomInBtn = document.getElementById('zoomInBtn');
+        this.zoomOutBtn = document.getElementById('zoomOutBtn');
+        const closeBtn = document.getElementById('closeBtn');
+        if (closeBtn) closeBtn.addEventListener('click', () => window.location.href = 'index.html');
+
+        this.visualizer.setData(this.currentData);
+        this.initializeVisualizationUI();
+    }
+
+    initializeVisualizationUI() {
+        if (!this.vizPanel || !this.xAxisSelect || !this.yAxisSelect) return;
+        this.vizPanel.style.display = 'block';
+        this.xAxisSelect.innerHTML = '';
+        this.yAxisSelect.innerHTML = '';
+
+        const newXAxisSelect = this.xAxisSelect.cloneNode(false);
+        this.xAxisSelect.parentNode.replaceChild(newXAxisSelect, this.xAxisSelect);
+        this.xAxisSelect = newXAxisSelect;
+
+        for (let i = 0; i < this.currentData.metadata.dimensions; i++) {
+            const dimName = this.currentData.metadata.dimNames[i];
+            const xOption = document.createElement('option');
+            xOption.value = i;
+            xOption.textContent = dimName;
+            this.xAxisSelect.appendChild(xOption);
+
+            const yOption = document.createElement('option');
+            yOption.value = i;
+            yOption.textContent = dimName;
+            this.yAxisSelect.appendChild(yOption);
+        }
+
+        if (this.currentData.metadata.dimensions === 1) {
+            const valueOption = document.createElement('option');
+            valueOption.value = 'value';
+            valueOption.textContent = '값';
+            this.yAxisSelect.appendChild(valueOption);
+            this.yAxisSelect.value = 'value';
+        } else {
+            this.yAxisSelect.value = '1';
+        }
+
+        this.xAxisSelect.addEventListener('change', () => {
+            if (!this.currentData) return;
+            const xDimIndex = parseInt(this.xAxisSelect.value);
+            const min = this.currentData.metadata.dimRangeMin[xDimIndex];
+            const max = this.currentData.metadata.dimRangeMax[xDimIndex];
+            this.visualizer.windowConfig.xMin = min;
+            this.visualizer.windowConfig.xMax = Math.min(min + this.visualizer.windowConfig.windowSize, max);
+            this.visualizer.windowConfig.step = (max - min) / 20;
+            this.updateWindowControls();
+        });
+
+        if (this.updateVizBtn) {
+            const newUpdateVizBtn = this.updateVizBtn.cloneNode(true);
+            this.updateVizBtn.parentNode.replaceChild(newUpdateVizBtn, this.updateVizBtn);
+            this.updateVizBtn = newUpdateVizBtn;
+            this.updateVizBtn.addEventListener('click', () => this.updateVisualization());
+        }
+
+        this.createDimensionFilters();
+
+        if (this.windowEnabledCheckbox && this.windowSizeInput && this.windowStartSlider) {
+            const newWindowEnabled = this.windowEnabledCheckbox.cloneNode(true);
+            this.windowEnabledCheckbox.parentNode.replaceChild(newWindowEnabled, this.windowEnabledCheckbox);
+            this.windowEnabledCheckbox = newWindowEnabled;
+
+            const newWindowSize = this.windowSizeInput.cloneNode(true);
+            this.windowSizeInput.parentNode.replaceChild(newWindowSize, this.windowSizeInput);
+            this.windowSizeInput = newWindowSize;
+
+            const newWindowStart = this.windowStartSlider.cloneNode(true);
+            this.windowStartSlider.parentNode.replaceChild(newWindowStart, this.windowStartSlider);
+            this.windowStartSlider = newWindowStart;
+        }
+
+        if (this.windowEnabledCheckbox) this.windowEnabledCheckbox.addEventListener('change', (e) => {
+            this.visualizer.toggleWindow(e.target.checked);
+            this.updateWindowControls();
+            this.updateVisualization();
+        });
+
+        if (this.windowSizeInput) this.windowSizeInput.addEventListener('input', (e) => {
+            const xDimIndex = parseInt(this.xAxisSelect.value || 0);
+            this.visualizer.resizeWindow(parseFloat(e.target.value), xDimIndex);
+            this.updateWindowControls();
+            this.updateVisualization();
+        });
+
+        if (this.windowStartSlider) this.windowStartSlider.addEventListener('input', (e) => {
+            const xDimIndex = parseInt(this.xAxisSelect.value || 0);
+            this.visualizer.setWindowStart(parseFloat(e.target.value), xDimIndex);
+            this.updateWindowControls();
+            this.updateVisualization();
+        });
+
+        if (this.zoomInBtn) {
+            this.zoomInBtn.addEventListener('click', () => {
+                const step = this.visualizer.windowConfig.step || 1;
+                const newSize = Math.max(step, this.visualizer.windowConfig.windowSize - step);
+                const xDimIndex = parseInt(this.xAxisSelect.value || 0);
+                this.visualizer.resizeWindow(newSize, xDimIndex);
+                this.windowSizeInput.value = newSize;
+                this.updateWindowControls();
+                this.updateVisualization();
+            });
+        }
+
+        if (this.zoomOutBtn) {
+            this.zoomOutBtn.addEventListener('click', () => {
+                const step = this.visualizer.windowConfig.step || 1;
+                const newSize = this.visualizer.windowConfig.windowSize + step;
+                const xDimIndex = parseInt(this.xAxisSelect.value || 0);
+                this.visualizer.resizeWindow(newSize, xDimIndex);
+                this.windowSizeInput.value = newSize;
+                this.updateWindowControls();
+                this.updateVisualization();
+            });
+        }
+
+        this.updateWindowControls();
+        this.updateVisualization();
+    }
+
+    createDimensionFilters() {
+        const filtersContainer = document.getElementById('dimensionFilters');
+        filtersContainer.innerHTML = '<h3>차원 필터</h3>';
+
+        for (let i = 0; i < this.currentData.metadata.dimensions; i++) {
+            const dimName = this.currentData.metadata.dimNames[i];
+            const min = this.currentData.metadata.dimRangeMin[i];
+            const max = this.currentData.metadata.dimRangeMax[i];
+            const interval = this.currentData.metadata.dimInterval[i];
+
+            const filterItem = document.createElement('div');
+            filterItem.className = 'filter-item';
+            filterItem.innerHTML = `
+                <h4>${dimName} (차원 ${i})</h4>
+                <div class="filter-controls">
+                    <div class="filter-value-control">
+                        <input type="range"
+                               id="filter-slider-${i}"
+                               min="${min}"
+                               max="${max}"
+                               step="${interval/10}"
+                               value="${(min + max) / 2}">
+                        <span id="filter-value-${i}">${((min + max) / 2).toFixed(2)}</span>
+                    </div>
+                    <div class="filter-condition">
+                        <button class="condition-btn active" data-dim="${i}" data-condition="any">모두</button>
+                        <button class="condition-btn" data-dim="${i}" data-condition="equal">=</button>
+                        <button class="condition-btn" data-dim="${i}" data-condition="greater">></button>
+                        <button class="condition-btn" data-dim="${i}" data-condition="less"><</button>
+                    </div>
+                </div>
+            `;
+
+            filtersContainer.appendChild(filterItem);
+
+            const slider = document.getElementById(`filter-slider-${i}`);
+            const valueSpan = document.getElementById(`filter-value-${i}`);
+
+            slider.addEventListener('input', (e) => {
+                const value = parseFloat(e.target.value);
+                valueSpan.textContent = value.toFixed(2);
+                this.visualizer.updateFilter(i, { value });
+                this.updateVisualization();
+            });
+
+            const conditionBtns = filterItem.querySelectorAll('.condition-btn');
+            conditionBtns.forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    const dim = parseInt(e.target.dataset.dim);
+                    const condition = e.target.dataset.condition;
+                    filterItem.querySelectorAll('.condition-btn').forEach(b => {
+                        b.classList.remove('active');
+                    });
+                    e.target.classList.add('active');
+                    this.visualizer.updateFilter(dim, { condition });
+                    this.updateVisualization();
+                });
+            });
+        }
+    }
+
+    updateWindowControls() {
+        if (!this.visualizer || !this.windowEnabledCheckbox || !this.windowSizeInput || !this.windowStartSlider) return;
+
+        const enabled = this.windowEnabledCheckbox.checked;
+        this.windowSizeInput.disabled = !enabled;
+        this.windowStartSlider.disabled = !enabled;
+
+        if (enabled && this.visualizer.windowConfig) {
+            const { xMin, xMax, windowSize } = this.visualizer.windowConfig;
+            this.windowRangeSpan.textContent = `범위: ${xMin.toFixed(1)} ~ ${xMax.toFixed(1)}`;
+            const xDimIndex = parseInt(this.xAxisSelect.value || 0);
+            const min = this.currentData.metadata.dimRangeMin[xDimIndex];
+            const max = this.currentData.metadata.dimRangeMax[xDimIndex];
+            const range = max - min;
+            if (range <= windowSize) {
+                this.windowStartSlider.min = min;
+                this.windowStartSlider.max = min;
+                this.windowStartSlider.value = min;
+                this.windowStartSlider.disabled = true;
+            } else {
+                this.windowStartSlider.disabled = false;
+                this.windowStartSlider.min = min;
+                this.windowStartSlider.max = max - windowSize;
+                this.windowStartSlider.step = 'any';
+                this.windowStartSlider.value = xMin;
+            }
+        } else {
+            this.windowRangeSpan.textContent = '범위: 전체';
+        }
+    }
+
+    updateVisualization() {
+        if (!this.currentData) return;
+        const xDimIndex = parseInt(this.xAxisSelect.value);
+        const yValue = this.yAxisSelect.value;
+        const yDimIndex = yValue === 'value' ? -1 : parseInt(yValue);
+        const colorScheme = this.colorSchemeSelect.value;
+        if (yDimIndex >= 0 && xDimIndex === yDimIndex) {
+            alert('X축과 Y축은 서로 다른 차원을 선택해주세요.');
+            return;
+        }
+        const displayedCount = this.visualizer.updateVisualization(xDimIndex, yDimIndex, colorScheme);
+        this.pointCountSpan.textContent = `표시된 포인트: ${displayedCount}개`;
+        this.updateWindowControls();
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    new VisualizationPage();
+});


### PR DESCRIPTION
## Summary
- separate index and visualization pages
- enable button to open visualization after data generation
- store generated data in localStorage and load it on visualization page
- improve window start slider with range checks
- style and button for closing visualization view

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685661869f9c8331823e6afa62104162